### PR TITLE
fix bestmove regexp

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -210,7 +210,7 @@ Engine.prototype.timeLimitedGoCommand = function (infoHandler,
                 infoHandler('info', lines[i]);
             } else if (stringifiedLine.startsWith('bestmove')) {
                 self.engineProcess.stdout.removeListener('data', engineStdoutListener);
-                var moveRegex = /bestmove (\w+)(.*)?/g;
+                var moveRegex = /bestmove \(?(\w+)\)?(.*)?/;
                 var match = moveRegex.exec(lines[i]);
                 if (match) {
                     deferred.resolve(utilities.convertToMoveObject(match[1]));
@@ -330,7 +330,7 @@ Engine.prototype.stopCommand = function () {
                     self.engineProcess.stdout.removeListener('data', self.goInfiniteListener);
                 }
                 self.engineProcess.stdout.removeListener('data', engineStdoutListener);
-                var moveRegex = /bestmove (\w+)(.*)?/g;
+                var moveRegex = /bestmove \(?(\w+)\)?(.*)?/;
                 var match = moveRegex.exec(lines[i]);
                 if (match) {
                     deferred.resolve(utilities.convertToMoveObject(match[1]));


### PR DESCRIPTION
Chess engine can bring string like "bestmove (none)". This can happen when the chess engine was checkmated